### PR TITLE
Convert filet to support parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ func TestFoo(t *testing.T) {
 
 `CleanUp` will call `t.Error` if something goes wrong when removing the file.
 
-You can also access the `Files` itself if you want to add a specificly
-named file to the cleanup list.
+You can also access the `Files` itself if you want to check the content, or add
+a specificly named file to the cleanup list.
 
 ```
-filet.Files = append(filet.Files, "path/to/my/named/file")
+fmt.Printf("%#v\n", filet.Files(t))
+
+filet.Append(t, "path/to/my/named/file")
+
+fmt.Printf("%#v\n", filet.Files(t))
 ```
 
 ## Helpers

--- a/filet_test.go
+++ b/filet_test.go
@@ -3,12 +3,15 @@ package filet
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTmpDir(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	path := TmpDir(t, "")
@@ -17,6 +20,8 @@ func TestTmpDir(t *testing.T) {
 }
 
 func TestTmpFile(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	// Test that file is actually created
@@ -32,6 +37,8 @@ func TestTmpFile(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	// Test that file is actually created
@@ -45,6 +52,8 @@ func TestFile(t *testing.T) {
 }
 
 func TestFileSays(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	file := TmpFile(t, "", "Gandhi")
@@ -60,6 +69,8 @@ func TestFileSays(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	file := TmpFile(t, "", "I exist")
@@ -70,6 +81,8 @@ func TestExists(t *testing.T) {
 }
 
 func TestDirContains(t *testing.T) {
+	t.Parallel()
+
 	defer CleanUp(t)
 
 	dir := TmpDir(t, "")
@@ -81,10 +94,9 @@ func TestDirContains(t *testing.T) {
 }
 
 func TestCleanUp(t *testing.T) {
-	defer CleanUp(t) // Kind of problematic.
+	t.Parallel()
 
-	// Clear Files
-	Files = make([]string, 0)
+	defer CleanUp(t) // Kind of problematic.
 
 	// Create test files
 	dir := TmpDir(t, "")
@@ -99,4 +111,29 @@ func TestCleanUp(t *testing.T) {
 	newDir := TmpDir(t, "")
 	assert.Equal(t, Exists(t, newDir), true,
 		"New files still exist after CleanUp")
+}
+
+func TestCleanUpEmpty(t *testing.T) {
+	t.Parallel()
+
+	defer CleanUp(t)
+}
+
+func TestMain(t *testing.T) {
+	theTest(t)
+}
+
+func TestMain2(t *testing.T) {
+	theTest(t)
+}
+
+func theTest(t *testing.T) {
+	t.Parallel()
+
+	defer CleanUp(t)
+
+	TmpDir(t, "")
+
+	time.Sleep(20 * time.Millisecond)
+	assert.Len(t, Files(t), 1)
 }


### PR DESCRIPTION
We create a new list of files per TestReporter. This needed a map, and
thus some helper functions to help with locking around the map.

This however changes the way you can access the `Files` array. You now
need to access it through the map key (see the README changes)

Fixed #5 

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>