### PR TITLE
add method for writing a binary file

### DIFF
--- a/filet.go
+++ b/filet.go
@@ -47,6 +47,23 @@ func TmpFile(t TestReporter, dir string, content string) afero.File {
 }
 
 /*
+TmpBinFile Creates a tmp file we can write byte slice to for us to use when testing
+*/
+func TmpBinFile(t TestReporter, dir string, content []byte) afero.File {
+	file, err := afero.TempFile(appFs, dir, "file")
+	defer file.Close()
+
+	if err != nil {
+		t.Error("Failed to create the tmpFile: "+file.Name(), err)
+	}
+
+	file.Write(content)
+	Files = append(Files, file.Name())
+
+	return file
+}
+
+/*
 File Creates a specified file for us to use when testing
 */
 func File(t TestReporter, path string, content string) afero.File {

--- a/filet_test.go
+++ b/filet_test.go
@@ -31,6 +31,22 @@ func TestTmpFile(t *testing.T) {
 		"TmpFile should create a file with content")
 }
 
+func TestTmpBinFile(t *testing.T) {
+	defer CleanUp(t)
+
+	// Test that file is actually created
+	file := TmpBinFile(t, "", []byte(""))
+	assert.Equal(t, Exists(t, file.Name()), true,
+		"TmpFile should create the file")
+
+	// Test that the content exists in the file
+	file = TmpBinFile(t, "", []byte("hey there"))
+	result := FileSays(t, file.Name(), []byte("hey there"))
+	assert.Equal(t, result, true,
+		"TmpFile should create a file with content")
+}
+
+
 func TestFile(t *testing.T) {
 	defer CleanUp(t)
 


### PR DESCRIPTION
This adds a method for writing to a binary file. Since we close the filer hanler after creation on `TmpFile` we can't write binary there. Trying to re-open the handler results in:

`golang.org/x/sys/unix.EBADF (9)`
